### PR TITLE
Fix last error shadowing on connection failures.

### DIFF
--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -195,7 +195,7 @@ module NATS
           current[:reconnect_attempts] = 0
         rescue NoServersError => e
           @disconnect_cb.call(e) if @disconnect_cb
-          raise e
+          raise @last_err || e
         rescue => e
           # Capture sticky error
           synchronize { @last_err = e }


### PR DESCRIPTION
Without this change, the error reported is NoServerError, hiding the real cause why the client could not connect to the server.

Signed-off-by: David Calavera <david.calavera@gmail.com>